### PR TITLE
fix: opacity is not working correctly [WTEL-1992]

### DIFF
--- a/src/modules/routing/modules/chat-gateways/mixins/webChatViewFormMixin.js
+++ b/src/modules/routing/modules/chat-gateways/mixins/webChatViewFormMixin.js
@@ -91,9 +91,18 @@ export default {
       this.setItemMetadata({ prop: 'accentColor', value: hsl });
     },
     setAlpha(value) {
-      this.color.hsl.a = value.a;
-      this.color.rgba.a = value.a;
-      this.color.a = value.a;
+      this.color = {
+        ...this.color,
+        rgba: {
+          ...this.color.rgba,
+          a: value.a,
+        },
+        hsl: {
+          ...this.color.hsl,
+          a: value.a,
+        },
+        a: value.a,
+      };
       this.setItemMetadata({ prop: 'btnOpacity', value: `${value.a}` });
     },
     restoreOpacity(value) {


### PR DESCRIPTION
повернув назад той метод, який на попередньому коміті замінив, бо без нього опасіті повзунок вимахується і не працює правильно