### PR TITLE
fix: deleting taba log in queue creation mode[WTEL-2542]

### DIFF
--- a/src/modules/contact-center/modules/queues/components/opened-queue.vue
+++ b/src/modules/contact-center/modules/queues/components/opened-queue.vue
@@ -258,10 +258,9 @@ export default {
         ...(queueTabsMap[this.queueType] || []),
         hooks,
         variables,
-        logs,
       ];
 
-      if (this.id) tabs.push(this.permissionsTab);
+      if (this.id) tabs.push(this.permissionsTab, logs);
       return tabs;
     },
 


### PR DESCRIPTION
Removed the deletion of the tab log in the mode of creating a new queue