### PR TITLE
feature: renaming the failed status in the Attempt result node[WTEL-2731]

### DIFF
--- a/src/app/locale/en/en.js
+++ b/src/app/locale/en/en.js
@@ -632,7 +632,7 @@ export default {
           timeout: 'Timeout',
           cancel: 'Cancel',
           success: 'Success',
-          failed: 'Failed',
+          failed: 'Abandoned',
           missed: 'Missed',
           expired: 'Expired',
         },


### PR DESCRIPTION
renaming the failed status in the Attempt result node