### PR TITLE
Fix: remove required value from calendar in "inbound queue"

### DIFF
--- a/src/modules/contact-center/modules/queues/components/opened-queue.vue
+++ b/src/modules/contact-center/modules/queues/components/opened-queue.vue
@@ -94,7 +94,6 @@ export default {
     const defaults = {
       itemInstance: {
         name: { required },
-        calendar: { required },
         priority: { minValue: minValue(0) },
         payload: {
           minOnlineAgents: { minValue: minValue(0) },
@@ -106,6 +105,7 @@ export default {
         return deepmerge(defaults, {
           itemInstance: {
             strategy: { required },
+            calendar: { required },
             payload: {
               originateTimeout: { required, minValue: minValue(0) },
             },
@@ -125,6 +125,7 @@ export default {
         return deepmerge(defaults, {
           itemInstance: {
             strategy: { required },
+            calendar: { required },
             payload: {
               maxAttempts: { required },
               originateTimeout: { required, minValue: minValue(0) },
@@ -137,6 +138,7 @@ export default {
         return deepmerge(defaults, {
           itemInstance: {
             strategy: { required },
+            calendar: { required },
             payload: {
               maxAttempts: { required },
               originateTimeout: { required, minValue: minValue(0) },
@@ -148,6 +150,7 @@ export default {
         return deepmerge(defaults, {
           itemInstance: {
             strategy: { required },
+            calendar: { required },
             payload: {
               maxAttempts: { required },
               originateTimeout: { required, minValue: minValue(0) },
@@ -159,6 +162,7 @@ export default {
         return deepmerge(defaults, {
           itemInstance: {
             strategy: { required },
+            calendar: { required },
             payload: {
               maxAttempts: { required },
               originateTimeout: { required, minValue: minValue(0) },
@@ -182,6 +186,7 @@ export default {
         return deepmerge(defaults, {
           itemInstance: {
             strategy: { required },
+            calendar: { required },
             payload: {
               maxAttempts: { required },
               waitBetweenRetries: { required, minValue: minValue(0) },
@@ -192,6 +197,7 @@ export default {
         return deepmerge(defaults, {
           itemInstance: {
             strategy: { required },
+            calendar: { required },
             payload: {
               maxAttempts: { required },
               originateTimeout: { required, minValue: minValue(0) },


### PR DESCRIPTION
Fix: remove required value from calendar in "inbound queue" and "Chat inbound queue" [WTEL-4671]

[WTEL-4671]: https://webitel.atlassian.net/browse/WTEL-4671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ