### PR TITLE
fix:r emoved the loader from the checkbox because the requests are fast, and since it tries to enable and quickly disable it, it causes flickering [WTEL-7738]

### DIFF
--- a/src/app/components/global-state-switcher.vue
+++ b/src/app/components/global-state-switcher.vue
@@ -1,7 +1,7 @@
 <template>
   <wt-switcher
     :model-value="globalState"
-    :disabled="disabled || isLoading"
+    :disabled="disabled"
     :label="$t('objects.lookups.skills.stateForAll')"
     @update:model-value="changeState"
   />
@@ -13,7 +13,6 @@ const globalState = defineModel({ default: false })
 
 interface stateSwitcherProps {
   disabled: boolean
-  isLoading: boolean
 }
 interface stateSwitcherEmits {
   (e: 'update:model-value', value: boolean): void
@@ -23,7 +22,6 @@ interface stateSwitcherEmits {
 
 withDefaults(defineProps<stateSwitcherProps>(), {
   disabled: false,
-  isLoading: false,
 })
 const emit = defineEmits<stateSwitcherEmits>()
 

--- a/src/modules/contact-center/modules/queues/components/the-queues.vue
+++ b/src/modules/contact-center/modules/queues/components/the-queues.vue
@@ -55,7 +55,6 @@
             />
             <global-state-switcher
               :model-value="globalState"
-              :is-loading="isLoadingGlobalState"
               @update:model-value="changeGlobalState"
               @onLoadGlobalState="fetchGlobalState"
             />
@@ -269,7 +268,6 @@ export default {
     QueueTypeProperties,
     routeName: RouteNames.QUEUES,
     globalState: false,
-    isLoadingGlobalState: false,
   }),
 
   computed: {
@@ -319,25 +317,19 @@ export default {
     },
     async fetchGlobalState() {
       try {
-        this.isLoadingGlobalState = true;
         const state = await QueueStateAPI.getQueuesGlobalState();
         this.globalState = !!state?.isAllEnabled;
       } catch (e) {
         console.error('Failed to fetch global state:', e);
-      } finally {
-        this.isLoadingGlobalState = false;
       }
     },
     async changeGlobalState(value) {
       try {
-        this.isLoadingGlobalState = true;
         await QueueStateAPI.setQueuesGlobalState({ enabled: value });
         this.globalState = value;
         await this.loadDataList();
       } catch (e) {
         console.error('Failed to change global state:', e);
-      } finally {
-        this.isLoadingGlobalState = false;
       }
     },
     openMembers(item) {


### PR DESCRIPTION
to do: removed the loader from the checkbox because the requests are fast, and since it tries to enable and quickly disable it, it causes flickering
task: https://webitel.atlassian.net/browse/WTEL-7738