### PR TITLE
chore: bump axios to 1.13.2 to resolve peer dependency conflict with webitel-sdk and bump ui-sdk to 26.02.145 [WTEL-9322](https://webitel.atlassian.net/browse/WTEL-9322)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@webitel/flow-ui-sdk": "^0.1.36",
 				"@webitel/styleguide": "~26.2",
 				"@webitel/ui-sdk": "~26.2",
-				"axios": "^1.x",
+				"axios": "1.13.2",
 				"clipboard-copy": "^4.0.1",
 				"cron-validator": "^1.3.1",
 				"cronstrue": "^2.13.0",
@@ -222,7 +222,6 @@
 			"integrity": "sha512-9+Fm1ahV8/2goSIPIqZnVitV5yHW5E5xTdKy33xnqGd45A9yVv5tTkudWzEXsbfBB47j9Xb3uYPZjAvV5RHbKA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@algolia/client-common": "5.20.3",
 				"@algolia/requester-browser-xhr": "5.20.3",
@@ -381,7 +380,6 @@
 			"integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.26.2",
@@ -875,7 +873,6 @@
 			"integrity": "sha512-QMT6QviX0WqXJCaiqVMiBUCr5WRQ1iFSjvOLoTk6auKukJMvnMzWucXpwZB0e8F00/1/BsS9DzcKgWH+CLqVuA==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
-			"peer": true,
 			"bin": {
 				"biome": "bin/biome"
 			},
@@ -3061,7 +3058,6 @@
 			"integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.20.0"
 			}
@@ -3945,7 +3941,6 @@
 			"version": "0.1.10",
 			"resolved": "https://registry.npmjs.org/@webitel/api-services/-/api-services-0.1.10.tgz",
 			"integrity": "sha512-THPk0/KSvW9rU2QYMLAXGOL+sQfU5K8b6M6SqZU5kEj7xGOX4WS6cxDLikqG7I4KOyZUkbX4eBQAXQd3U1r0dw==",
-			"peer": true,
 			"dependencies": {
 				"@faker-js/faker": "^9.7.0",
 				"lodash-es": "^4.17.21",
@@ -4089,13 +4084,12 @@
 		"node_modules/@webitel/styleguide": {
 			"version": "26.2.9",
 			"resolved": "https://registry.npmjs.org/@webitel/styleguide/-/styleguide-26.2.9.tgz",
-			"integrity": "sha512-p6FNu5qAdUXcJg3fWpyX5kaq77lc4tdTxgQKIRhQUIe+AYenezpb8YKupdgDRjcb+8IN7wggIP0cgVueC3ojZw==",
-			"peer": true
+			"integrity": "sha512-p6FNu5qAdUXcJg3fWpyX5kaq77lc4tdTxgQKIRhQUIe+AYenezpb8YKupdgDRjcb+8IN7wggIP0cgVueC3ojZw=="
 		},
 		"node_modules/@webitel/ui-sdk": {
-			"version": "26.2.126",
-			"resolved": "https://registry.npmjs.org/@webitel/ui-sdk/-/ui-sdk-26.2.126.tgz",
-			"integrity": "sha512-g/NnhbCvrswSpevjEAgTo34MEvRsL+PUNT+h4ptj03o27+bbYhqa5x8c/EAdtCs/FpieO6Rczl/xlmcbpE7HdA==",
+			"version": "26.2.145",
+			"resolved": "https://registry.npmjs.org/@webitel/ui-sdk/-/ui-sdk-26.2.145.tgz",
+			"integrity": "sha512-w1ihjE/wwie1fInKCYWcPX0IckYaNmke0H9Gyvm8jigiiESNlGOrYBfdJgSjJFEZzMUy8lB7m0z5/Pcp8ON/Ig==",
 			"workspaces": [
 				"./packages/api-services",
 				"./packages/styleguide"
@@ -4216,7 +4210,6 @@
 			"integrity": "sha512-iNC6BGvipaalFfDfDnXUje8GUlW5asj0cTMsZJwO/0rhsyLx1L7GZFAY8wW+eQ6AM4Yge2p5GSE5hrBlfSD90Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@algolia/client-abtesting": "5.20.3",
 				"@algolia/client-analytics": "5.20.3",
@@ -4316,7 +4309,8 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"license": "Python-2.0"
+			"license": "Python-2.0",
+			"peer": true
 		},
 		"node_modules/array-buffer-byte-length": {
 			"version": "1.0.2",
@@ -4445,14 +4439,13 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.8.4",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-			"integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+			"integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"follow-redirects": "^1.15.6",
-				"form-data": "^4.0.0",
+				"form-data": "^4.0.4",
 				"proxy-from-env": "^1.1.0"
 			}
 		},
@@ -4716,7 +4709,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"caniuse-lite": "^1.0.30001688",
 				"electron-to-chromium": "^1.5.73",
@@ -5568,7 +5560,6 @@
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
 			"integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/kossnocorp"
@@ -5621,7 +5612,6 @@
 			"resolved": "https://registry.npmjs.org/deep-copy/-/deep-copy-1.4.2.tgz",
 			"integrity": "sha512-VxZwQ/1+WGQPl5nE67uLhh7OqdrmqI1OazrraO9Bbw/M8Bt6Mol/RxzDA6N6ZgRXpsG/W9PgUj8E1LHHBEq2GQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=4.0.0"
 			}
@@ -5641,7 +5631,6 @@
 			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
 			"integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"array-buffer-byte-length": "^1.0.0",
 				"call-bind": "^1.0.5",
@@ -5680,7 +5669,6 @@
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
 			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6465,7 +6453,6 @@
 			"integrity": "sha512-xx560wGBk7seZ6y933idtjJQc1l+ck+pI3sKvhKozdBV1dRZoKhkW5xoCaFv9tQiX5RH1xfSxjuNu6g+lmN/gw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"tabbable": "^6.2.0"
 			}
@@ -6523,14 +6510,15 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-			"integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
 				"mime-types": "^2.1.12"
 			},
 			"engines": {
@@ -6813,7 +6801,6 @@
 			"integrity": "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"entities": "^4.5.0",
 				"webidl-conversions": "^7.0.0",
@@ -7915,7 +7902,6 @@
 			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
 			"integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
 			"license": "(MIT OR GPL-3.0-or-later)",
-			"peer": true,
 			"dependencies": {
 				"lie": "~3.3.0",
 				"pako": "~1.0.2",
@@ -7927,8 +7913,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/jszip-utils/-/jszip-utils-0.1.0.tgz",
 			"integrity": "sha512-tBNe0o3HAf8vo0BrOYnLPnXNo5A3KsRMnkBFYjh20Y3GPYGfgyoclEMgvVchx0nnL+mherPi74yLPIusHUQpZg==",
-			"license": "(MIT OR GPL-3.0)",
-			"peer": true
+			"license": "(MIT OR GPL-3.0)"
 		},
 		"node_modules/klona": {
 			"version": "2.0.6",
@@ -8236,6 +8221,7 @@
 			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
 			"integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"uc.micro": "^2.0.0"
 			}
@@ -8518,8 +8504,7 @@
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
 			"integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/lodash.throttle": {
 			"version": "4.1.1",
@@ -8671,7 +8656,8 @@
 			"version": "2.3.9",
 			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
 			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/magic-string": {
 			"version": "0.30.17",
@@ -8688,7 +8674,6 @@
 			"integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/parser": "^7.25.4",
 				"@babel/types": "^7.25.4",
@@ -8723,6 +8708,7 @@
 			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
 			"integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"argparse": "^2.0.1",
 				"entities": "^4.4.0",
@@ -8788,7 +8774,8 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
 			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/media-captions": {
 			"version": "1.0.4",
@@ -9068,8 +9055,7 @@
 			"resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
 			"integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
 			"devOptional": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/mkdirp": {
 			"version": "3.0.1",
@@ -10148,6 +10134,7 @@
 			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
 			"integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -10515,7 +10502,6 @@
 			"integrity": "sha512-489gTVMzAYdiZHFVA/ig/iYFllCcWFHMvUHI1rpFmkoUtRlQxqh6/yiNqnYibjMZ2b/+FUQwldG+aLsEt6bglQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.6"
 			},
@@ -10629,7 +10615,6 @@
 			"integrity": "sha512-Uk8WpxM5v+0cMR0XjX9KfRIacmSG86RH4DCCZjLU2rFh5tyutt9siAXJ7G+YfxQ99Q6wrRMbMlVl6KqUms71ag==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"chokidar": "^4.0.0",
 				"immutable": "^5.0.2",
@@ -11488,7 +11473,6 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -11601,8 +11585,7 @@
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"peer": true
+			"license": "0BSD"
 		},
 		"node_modules/tty-browserify": {
 			"version": "0.0.1",
@@ -11628,6 +11611,7 @@
 			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.26.11.tgz",
 			"integrity": "sha512-sFEgRRtrcDl2FxVP58Ze++ZK2UQAEvtvvH8rRlig1Ja3o7dDaMHmaBfvJmdGnNEFaLTpQsN8dpvZaTqJSu/Ugw==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"lunr": "^2.3.9",
 				"markdown-it": "^14.1.0",
@@ -11662,6 +11646,7 @@
 			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.29.2.tgz",
 			"integrity": "sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@shikijs/engine-javascript": "1.29.2",
 				"@shikijs/engine-oniguruma": "1.29.2",
@@ -11676,6 +11661,7 @@
 			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.29.2.tgz",
 			"integrity": "sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@shikijs/types": "1.29.2",
 				"@shikijs/vscode-textmate": "^10.0.1",
@@ -11687,6 +11673,7 @@
 			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.2.tgz",
 			"integrity": "sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@shikijs/types": "1.29.2",
 				"@shikijs/vscode-textmate": "^10.0.1"
@@ -11697,6 +11684,7 @@
 			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-1.29.2.tgz",
 			"integrity": "sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@shikijs/types": "1.29.2"
 			}
@@ -11706,6 +11694,7 @@
 			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-1.29.2.tgz",
 			"integrity": "sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@shikijs/types": "1.29.2"
 			}
@@ -11715,6 +11704,7 @@
 			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.29.2.tgz",
 			"integrity": "sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@shikijs/vscode-textmate": "^10.0.1",
 				"@types/hast": "^3.0.4"
@@ -11725,6 +11715,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
 			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
@@ -11734,6 +11725,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
 			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
 			},
@@ -11749,6 +11741,7 @@
 			"resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.3.0.tgz",
 			"integrity": "sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"emoji-regex-xs": "^1.0.0",
 				"regex": "^5.1.1",
@@ -11760,6 +11753,7 @@
 			"resolved": "https://registry.npmjs.org/regex/-/regex-5.1.1.tgz",
 			"integrity": "sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"regex-utilities": "^2.3.0"
 			}
@@ -11769,6 +11763,7 @@
 			"resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-5.1.1.tgz",
 			"integrity": "sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"regex": "^5.1.1",
 				"regex-utilities": "^2.3.0"
@@ -11779,6 +11774,7 @@
 			"resolved": "https://registry.npmjs.org/shiki/-/shiki-1.29.2.tgz",
 			"integrity": "sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@shikijs/core": "1.29.2",
 				"@shikijs/engine-javascript": "1.29.2",
@@ -11795,7 +11791,6 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
 			"integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -11808,7 +11803,8 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
 			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/ufo": {
 			"version": "1.6.1",
@@ -12102,7 +12098,6 @@
 			"resolved": "https://registry.npmjs.org/vidstack/-/vidstack-1.12.13.tgz",
 			"integrity": "sha512-vuNeyRmWoH/7EoFVDYjp9nkgcqtCMmal518LDeb78dYKgWb+p6+vtY0AzDhrkBv5q1UiCn+xwmjMmwvSlPLuhQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@floating-ui/dom": "^1.6.10",
 				"lit-html": "^2.8.0",
@@ -12132,7 +12127,6 @@
 			"resolved": "https://registry.npmjs.org/rolldown-vite/-/rolldown-vite-7.3.1.tgz",
 			"integrity": "sha512-LYzdNAjRHhF2yA4JUQm/QyARyi216N2rpJ0lJZb8E9FU2y5v6Vk+xq/U4XBOxMefpWixT5H3TslmAHm1rqIq2w==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@oxc-project/runtime": "0.101.0",
 				"fdir": "^6.5.0",
@@ -12833,7 +12827,6 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -13382,7 +13375,6 @@
 			"integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.21.3",
 				"postcss": "^8.4.43",
@@ -13443,7 +13435,6 @@
 			"integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@vitest/expect": "2.1.9",
 				"@vitest/mocker": "2.1.9",
@@ -13603,7 +13594,6 @@
 			"resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
 			"integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@vue/compiler-dom": "3.5.13",
 				"@vue/compiler-sfc": "3.5.13",
@@ -13705,7 +13695,6 @@
 			"resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.2.8.tgz",
 			"integrity": "sha512-vJ123v/PXCZntd6Qj5Jumy7UBmIuE92VrtdX+AXr+1WzdBHojiBxnAxdfctUFL+/JIN+VQH4BhsfTtiGsvVObg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@intlify/core-base": "11.2.8",
 				"@intlify/shared": "11.2.8",
@@ -13755,7 +13744,6 @@
 			"resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.0.tgz",
 			"integrity": "sha512-HDuk+PuH5monfNuY+ct49mNmkCRK4xJAV9Ts4z9UFc4rzdDnxQLyCMGGc8pKhZhHTVzfanpNwB/lwqevcBwI4w==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@vue/devtools-api": "^6.6.4"
 			},
@@ -13772,7 +13760,6 @@
 			"integrity": "sha512-3EVHlxtpMXcb5bCaK7QDFTbEkMusDfVk0HVRrkv5hEb+Clpu9a96lKUXJAeD/akRlkoA4H8MCHgBDN19S6FnzA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@volar/typescript": "~2.4.11",
 				"@vue/language-core": "2.2.4"
@@ -13820,7 +13807,6 @@
 			"resolved": "https://registry.npmjs.org/webitel-sdk/-/webitel-sdk-26.1.3.tgz",
 			"integrity": "sha512-KPNJkXX+O759TEGGODXci+fXjGJc2aZaX+f81KH07oZcdKCHoeZ2Sbg032ncZ5y60lcdiXqRG3si07+JJ62L7w==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/webrtc": "~0.0.41",
 				"deep-copy": "1.4.2",
@@ -14273,7 +14259,6 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
 			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"@webitel/flow-ui-sdk": "^0.1.36",
 		"@webitel/styleguide": "~26.2",
 		"@webitel/ui-sdk": "~26.2",
-		"axios": "1.8.4",
+		"axios": "1.13.2",
 		"clipboard-copy": "^4.0.1",
 		"cron-validator": "^1.3.1",
 		"cronstrue": "^2.13.0",


### PR DESCRIPTION
webitel-sdk хоче axios 1.13.2
@webitel/ui-sdk хоче axios ^1.8.3

Виник конфлікт - в package.json був захардкоджений "axios": "1.8.4", npm не міг задовольнити обидва peer deps одночасно.

Я глянув як це в мейні пофіксилось.

Просто підняли версію axios до ^1.13.2 - і конфлікт зник, бо ^1.8.3 означає >=1.8.3 <2.0.0, тому 1.13.2 задовольняє обидва пакети одночасно.


Я зробив так само і в 26.02 в адмінці
І ніби як нема breaking changes і все працює