### PR TITLE
feat: add IM chat queue type

### DIFF
--- a/src/app/locale/en/en.js
+++ b/src/app/locale/en/en.js
@@ -953,6 +953,9 @@ export default {
 				chatInboundQueue: 'Chat inbound queue',
 				chatInboundQueueDescription:
 					'The same as inbound queue, but with chats',
+				imChatQueue: 'IM chat queue',
+				imChatQueueDescription:
+					'The same as chat inbound queue, but for instant messaging',
 				inboundJobQueue: 'Inbound task queue',
 				inboundJobQueueDescription: 'Inbound task queue',
 				outboundJobQueue: 'Outbound task queue',

--- a/src/app/locale/es/es.js
+++ b/src/app/locale/es/es.js
@@ -957,6 +957,9 @@ export default {
 				chatInboundQueue: 'Cola de chat de entrada',
 				chatInboundQueueDescription:
 					'Lo mismo que la cola de entrada, pero con chats',
+				imChatQueue: 'Cola de chat IM',
+				imChatQueueDescription:
+					'Lo mismo que la cola de chat, pero para mensajería instantánea',
 				inboundJobQueue: 'Cola de tarea de entrada',
 				inboundJobQueueDescription: 'Cola de tarea de entrada',
 				outboundJobQueue: 'Cola de tarea de salida',

--- a/src/app/locale/kz/kz.js
+++ b/src/app/locale/kz/kz.js
@@ -948,6 +948,9 @@ export default {
 					'Прогнозды дайындық бір уақытта көп сандарды қоңырауға мүмкіндік береді. Қолданушы жауап бергенде, агент оларға қосылады.',
 				chatInboundQueue: 'Чат кіру қоймасы',
 				chatInboundQueueDescription: 'Кіру қоймасымен бірдей, бірақ чаттармен',
+				imChatQueue: 'IM чат қоймасы',
+				imChatQueueDescription:
+					'Чат қоймасымен бірдей, бірақ мессенджерлер үшін',
 				inboundJobQueue: 'Кіру тапсырмасы қоймасы',
 				inboundJobQueueDescription: 'Кіру тапсырмасы қоймасы',
 				outboundJobQueue: 'Шығыс тапсырмасы қоймасы',

--- a/src/app/locale/pl/pl.js
+++ b/src/app/locale/pl/pl.js
@@ -955,6 +955,9 @@ export default {
 				chatInboundQueue: 'Kolejka przychodząca czatu',
 				chatInboundQueueDescription:
 					'Tak samo jak kolejka przychodząca, ale z czatami',
+				imChatQueue: 'Kolejka czatu IM',
+				imChatQueueDescription:
+					'Tak samo jak kolejka czatu, ale dla komunikatorów',
 				inboundJobQueue: 'Kolejka zadań przychodzących',
 				inboundJobQueueDescription: 'Kolejka zadań przychodzących',
 				outboundJobQueue: 'Kolejka zadań wychodzących',

--- a/src/app/locale/ro/ro.js
+++ b/src/app/locale/ro/ro.js
@@ -956,6 +956,9 @@ export default {
 				chatInboundQueue: 'Coadă inbound chat',
 				chatInboundQueueDescription:
 					'La fel ca și coada inbound, dar cu chat-uri',
+				imChatQueue: 'Coadă chat IM',
+				imChatQueueDescription:
+					'La fel ca și coada de chat, dar pentru mesagerie instant',
 				inboundJobQueue: 'Coadă sarcină inbound',
 				inboundJobQueueDescription: 'Coadă sarcină inbound',
 				outboundJobQueue: 'Coadă sarcină outbound',

--- a/src/app/locale/ru/ru.js
+++ b/src/app/locale/ru/ru.js
@@ -961,6 +961,9 @@ export default {
 				chatInboundQueue: 'Входящая очередь чатов',
 				chatInboundQueueDescription:
 					'То же самое, что и Входящая очередь, но с чатами',
+				imChatQueue: 'Очередь IM-чатов',
+				imChatQueueDescription:
+					'То же самое, что и очередь чатов, но для мессенджеров',
 				inboundJobQueue: 'Входящая очередь заданий',
 				inboundJobQueueDescription: 'Входящая очередь заданий',
 				outboundJobQueue: 'Исходящая очередь заданий',

--- a/src/app/locale/uk/uk.js
+++ b/src/app/locale/uk/uk.js
@@ -963,6 +963,8 @@ export default {
 					'Вихідна кампанія без попереднього резервування оператора для максимального скорочення часу очікування дзвінка.',
 				chatInboundQueue: 'Вхідна черга чатів',
 				chatInboundQueueDescription: 'Така ж вхідна черга, але для чатів',
+				imChatQueue: 'Черга IM-чатів',
+				imChatQueueDescription: 'Така ж черга чатів, але для месенджерів',
 				inboundJobQueue: 'Вхідна черга завдань',
 				inboundJobQueueDescription: 'Вхідна черга завдань',
 				outboundJobQueue: 'Вихідна черга завдань',

--- a/src/app/locale/uz/uz.js
+++ b/src/app/locale/uz/uz.js
@@ -957,6 +957,9 @@ export default {
 				chatInboundQueue: "Chat kirish qo'yuv",
 				chatInboundQueueDescription:
 					"Kirish qo'yuv bilan bir xil, lekin chatlar bilan",
+				imChatQueue: "IM chat qo'yuv",
+				imChatQueueDescription:
+					"Chat qo'yuv bilan bir xil, lekin messenjerlar uchun",
 				inboundJobQueue: "Kirish vazifa qo'yuv",
 				inboundJobQueueDescription: "Kirish vazifa qo'yuv",
 				outboundJobQueue: "Chiqish vazifa qo'yuv",

--- a/src/app/locale/vi/vi.js
+++ b/src/app/locale/vi/vi.js
@@ -952,6 +952,9 @@ export default {
 				chatInboundQueue: 'Hàng đợi nhập trò chuyện',
 				chatInboundQueueDescription:
 					'Giống như hàng đợi nhập, nhưng với trò chuyện',
+				imChatQueue: 'Hàng đợi trò chuyện IM',
+				imChatQueueDescription:
+					'Giống như hàng đợi trò chuyện, nhưng cho tin nhắn tức thời',
 				inboundJobQueue: 'Hàng đợi nhiệm vụ nhập',
 				inboundJobQueueDescription: 'Hàng đợi nhiệm vụ nhập',
 				outboundJobQueue: 'Hàng đợi nhiệm vụ xuất',

--- a/src/modules/contact-center/modules/queues/components/opened-queue-params.vue
+++ b/src/modules/contact-center/modules/queues/components/opened-queue-params.vue
@@ -312,8 +312,8 @@
 </template>
 
 <script>
-import { mapActions } from 'vuex';
 import { QueueType } from '@webitel/ui-sdk/enums';
+import { mapActions } from 'vuex';
 
 import { useUserAccessControl } from '../../../../../app/composables/useUserAccessControl';
 import openedTabComponentMixin from '../../../../../app/mixins/objectPagesMixins/openedObjectTabMixin/openedTabComponentMixin';

--- a/src/modules/contact-center/modules/queues/components/opened-queue.vue
+++ b/src/modules/contact-center/modules/queues/components/opened-queue.vue
@@ -50,9 +50,8 @@
 <script>
 import { useVuelidate } from '@vuelidate/core';
 import { minValue, required } from '@vuelidate/validators';
-import { WtObject } from '@webitel/ui-sdk/enums';
+import { QueueType, WtObject } from '@webitel/ui-sdk/enums';
 import deepmerge from 'deepmerge';
-import { QueueType } from '@webitel/ui-sdk/enums';
 
 import { useUserAccessControl } from '../../../../../app/composables/useUserAccessControl';
 import openedObjectMixin from '../../../../../app/mixins/objectPagesMixins/openedObjectMixin/openedObjectMixin';

--- a/src/modules/contact-center/modules/queues/components/opened-queue.vue
+++ b/src/modules/contact-center/modules/queues/components/opened-queue.vue
@@ -283,6 +283,7 @@ export default {
 					},
 				});
 			case QueueType.CHAT_INBOUND_QUEUE:
+			case QueueType.IM_CHAT_QUEUE:
 				return deepmerge(defaults, {
 					itemInstance: {
 						strategy: {
@@ -468,6 +469,11 @@ export default {
 					amd,
 				],
 				[QueueType.CHAT_INBOUND_QUEUE]: [
+					processing,
+					agents,
+					skills,
+				],
+				[QueueType.IM_CHAT_QUEUE]: [
 					processing,
 					agents,
 					skills,

--- a/src/modules/contact-center/modules/queues/lookups/QueueTypeProperties.lookup.js
+++ b/src/modules/contact-center/modules/queues/lookups/QueueTypeProperties.lookup.js
@@ -261,6 +261,7 @@ const QueueTypeProperties = Object.freeze({
 			'taskProcessing.prolongationOptions.prolongationTimeSec',
 		],
 	},
+	// hide me https://webitel.atlassian.net/browse/WS-2
 	[QueueType.IM_CHAT_QUEUE]: {
 		locale: baseLocale.concat('.imChatQueue'),
 		subpath: 'im-chat-queue',

--- a/src/modules/contact-center/modules/queues/lookups/QueueTypeProperties.lookup.js
+++ b/src/modules/contact-center/modules/queues/lookups/QueueTypeProperties.lookup.js
@@ -261,6 +261,39 @@ const QueueTypeProperties = Object.freeze({
 			'taskProcessing.prolongationOptions.prolongationTimeSec',
 		],
 	},
+	[QueueType.IM_CHAT_QUEUE]: {
+		locale: baseLocale.concat('.imChatQueue'),
+		subpath: 'im-chat-queue',
+		controls: [
+			// general specific
+			'strategy',
+			'team',
+			// params specific
+			'maxWaitTime',
+			'maxWaitingSize',
+			'maxIdleAgent',
+			'maxIdleClient',
+			'maxIdleDialog',
+			'stickyAgent',
+			'stickyAgentSec',
+			'stickyIgnoreStatus',
+			'ignoreCalendar',
+			'minOnlineAgents',
+			'manualDistribution',
+			'lastMessageTimeout',
+			'maxMemberLimit',
+
+			// processing specific
+			'taskProcessing.enabled',
+			'taskProcessing.formSchema',
+			'taskProcessing.sec',
+			'taskProcessing.renewalSec',
+			'taskProcessing.prolongationOptions.enabled',
+			'taskProcessing.prolongationOptions.renewalSec',
+			'taskProcessing.prolongationOptions.repeatsNumber',
+			'taskProcessing.prolongationOptions.prolongationTimeSec',
+		],
+	},
 	[QueueType.INBOUND_JOB_QUEUE]: {
 		locale: baseLocale.concat('.inboundJobQueue'),
 		subpath: 'inbound-job-queue',

--- a/src/modules/contact-center/modules/queues/modules/filters/store/QueueTypeOptions.js
+++ b/src/modules/contact-center/modules/queues/modules/filters/store/QueueTypeOptions.js
@@ -2,7 +2,10 @@ import { QueueType } from '@webitel/ui-sdk/enums';
 
 export default Object.keys(QueueType)
 
-	.filter((key) => Number.isNaN(+key))
+	.filter(
+		(key) =>
+			Number.isNaN(+key) /* && QueueType[key] !== QueueType.IM_CHAT_QUEUE */, // hide me https://webitel.atlassian.net/browse/WS-2
+	)
 	.map((key) => ({
 		name: key,
 		value: `${QueueType[key]}`,

--- a/src/modules/contact-center/modules/queues/store/_internals/queueSchema/imChatQueue.js
+++ b/src/modules/contact-center/modules/queues/store/_internals/queueSchema/imChatQueue.js
@@ -1,0 +1,34 @@
+import { QueueType } from '@webitel/ui-sdk/enums';
+
+import { Strategy } from '../enums/Strategy.enum';
+import { TimeBaseScore } from '../enums/TimeBaseScore.enum';
+import queue from './defaults/defaultQueue';
+import processing from './defaults/processing';
+
+const imChatQueue = () => ({
+	...queue(),
+	type: QueueType.IM_CHAT_QUEUE,
+	team: {}, // required
+	strategy: Strategy.FIFO, // required
+	formSchema: {},
+	stickyAgent: false,
+	taskProcessing: processing(),
+	payload: {
+		discardAbandonedAfter: 0,
+		timeBaseScore: TimeBaseScore.QUEUE, // required
+		maxWaitTime: 60 * 60, // required
+		stickyAgentSec: 5,
+		stickyIgnoreStatus: false,
+		ignoreCalendar: false,
+		maxIdleAgent: 60 * 60, // hour
+		maxIdleClient: 60 * 60, // hour
+		maxIdleDialog: 0,
+		maxWaitingSize: 0,
+		minOnlineAgents: 0,
+		manualDistribution: false,
+		lastMessageTimeout: false,
+		maxMemberLimit: 0,
+	},
+});
+
+export default imChatQueue;

--- a/src/modules/contact-center/modules/queues/store/queues.js
+++ b/src/modules/contact-center/modules/queues/store/queues.js
@@ -1,5 +1,5 @@
-import deepMerge from 'deepmerge';
 import { QueueType } from '@webitel/ui-sdk/enums';
+import deepMerge from 'deepmerge';
 
 import ObjectStoreModule from '../../../../../app/store/BaseStoreModules/StoreModules/ObjectStoreModule';
 import PermissionsStoreModule from '../../../../../app/store/BaseStoreModules/StoreModules/PermissionsStoreModule/PermissionsStoreModule';

--- a/src/modules/contact-center/modules/queues/store/queues.js
+++ b/src/modules/contact-center/modules/queues/store/queues.js
@@ -15,6 +15,7 @@ import skills from '../modules/skills/store/queue-skills';
 import headers from './_internals/headers';
 import defaultChatInboundQueueState from './_internals/queueSchema/chatInboundQueue';
 import defaultQueueState from './_internals/queueSchema/defaults/defaultQueue';
+import defaultImChatQueueState from './_internals/queueSchema/imChatQueue';
 import defaultInboundJobQueueState from './_internals/queueSchema/inboundJobQueue';
 import defaultInboundQueueState from './_internals/queueSchema/inboundQueue';
 import defaultOfflineQueueState from './_internals/queueSchema/offlineQueue';
@@ -36,6 +37,7 @@ const queueStateMap = {
 	[QueueType.PROGRESSIVE_DIALER]: defaultProgressiveDialerState,
 	[QueueType.PREDICTIVE_DIALER]: defaultPredictiveDialerState,
 	[QueueType.CHAT_INBOUND_QUEUE]: defaultChatInboundQueueState,
+	[QueueType.IM_CHAT_QUEUE]: defaultImChatQueueState,
 	[QueueType.INBOUND_JOB_QUEUE]: defaultInboundJobQueueState,
 	[QueueType.OUTBOUND_JOB_QUEUE]: defaultOutboundJobQueueState,
 };

--- a/src/modules/integrations/modules/import-csv/components/opened-import-csv-general.vue
+++ b/src/modules/integrations/modules/import-csv/components/opened-import-csv-general.vue
@@ -35,8 +35,7 @@
 </template>
 
 <script>
-import { WtObject } from '@webitel/ui-sdk/enums';
-import { QueueType } from '@webitel/ui-sdk/enums';
+import { QueueType, WtObject } from '@webitel/ui-sdk/enums';
 
 import { useUserAccessControl } from '../../../../../app/composables/useUserAccessControl';
 import openedTabComponentMixin from '../../../../../app/mixins/objectPagesMixins/openedObjectTabMixin/openedTabComponentMixin';

--- a/src/modules/integrations/modules/import-csv/components/opened-import-csv-general.vue
+++ b/src/modules/integrations/modules/import-csv/components/opened-import-csv-general.vue
@@ -65,6 +65,7 @@ export default {
 				QueueType.PROGRESSIVE_DIALER,
 				QueueType.PREDICTIVE_DIALER,
 				QueueType.CHAT_INBOUND_QUEUE,
+				QueueType.IM_CHAT_QUEUE,
 				QueueType.INBOUND_JOB_QUEUE,
 				QueueType.OUTBOUND_JOB_QUEUE,
 			];


### PR DESCRIPTION
 [WS-2](https://webitel.atlassian.net/browse/WS-2)

Mirror the inbound chat queue for the new IM_CHAT_QUEUE type: schema, type properties lookup, store state map, validation and tabs in opened-queue, plus locale strings for all languages.

[WS-2]: https://webitel.atlassian.net/browse/WS-2?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ