### PR TITLE
fix: add data-key prop with null value to multi-select in opened-queu…

### DIFF
--- a/src/modules/contact-center/modules/queues/components/shared/amd/opened-queue-amd.vue
+++ b/src/modules/contact-center/modules/queues/components/shared/amd/opened-queue-amd.vue
@@ -101,6 +101,7 @@
           :label="$t('objects.ccenter.queues.positiveLabels')"
           :options="AmdAiLabels"
           :model-value="itemInstance.payload.amd.positive"
+          :data-key="null"
           chips-view
           allow-custom-values
           @update:model-value="setAmdItemProp({ prop: 'positive', value: $event })"


### PR DESCRIPTION
…e-amd component [WTEL-9819](https://webitel.atlassian.net/browse/WTEL-9819)

[WTEL-9819]: https://webitel.atlassian.net/browse/WTEL-9819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ