### PR TITLE
feat: gate IM chat queue behind staging env [WTEL-9821]

### DIFF
--- a/src/modules/contact-center/modules/queues/lookups/QueueTypeProperties.lookup.js
+++ b/src/modules/contact-center/modules/queues/lookups/QueueTypeProperties.lookup.js
@@ -263,40 +263,44 @@ const QueueTypeProperties = Object.freeze({
 			'taskProcessing.prolongationOptions.prolongationTimeSec',
 		],
 	},
-	// hide me https://webitel.atlassian.net/browse/WS-2
-	[QueueType.IM_CHAT_QUEUE]: {
-		locale: baseLocale.concat('.imChatQueue'),
-		subpath: 'im-chat-queue',
-		controls: [
-			// general specific
-			'strategy',
-			'team',
-			// params specific
-			'maxWaitTime',
-			'maxWaitingSize',
-			'maxIdleAgent',
-			'maxIdleClient',
-			'maxIdleDialog',
-			'stickyAgent',
-			'stickyAgentSec',
-			'stickyIgnoreStatus',
-			'ignoreCalendar',
-			'minOnlineAgents',
-			'manualDistribution',
-			'lastMessageTimeout',
-			'maxMemberLimit',
+	// staging only https://webitel.atlassian.net/browse/WS-2
+	...(import.meta.env.VITE_STAGING_ENV
+		? {
+				[QueueType.IM_CHAT_QUEUE]: {
+					locale: baseLocale.concat('.imChatQueue'),
+					subpath: 'im-chat-queue',
+					controls: [
+						// general specific
+						'strategy',
+						'team',
+						// params specific
+						'maxWaitTime',
+						'maxWaitingSize',
+						'maxIdleAgent',
+						'maxIdleClient',
+						'maxIdleDialog',
+						'stickyAgent',
+						'stickyAgentSec',
+						'stickyIgnoreStatus',
+						'ignoreCalendar',
+						'minOnlineAgents',
+						'manualDistribution',
+						'lastMessageTimeout',
+						'maxMemberLimit',
 
-			// processing specific
-			'taskProcessing.enabled',
-			'taskProcessing.formSchema',
-			'taskProcessing.sec',
-			'taskProcessing.renewalSec',
-			'taskProcessing.prolongationOptions.enabled',
-			'taskProcessing.prolongationOptions.renewalSec',
-			'taskProcessing.prolongationOptions.repeatsNumber',
-			'taskProcessing.prolongationOptions.prolongationTimeSec',
-		],
-	},
+						// processing specific
+						'taskProcessing.enabled',
+						'taskProcessing.formSchema',
+						'taskProcessing.sec',
+						'taskProcessing.renewalSec',
+						'taskProcessing.prolongationOptions.enabled',
+						'taskProcessing.prolongationOptions.renewalSec',
+						'taskProcessing.prolongationOptions.repeatsNumber',
+						'taskProcessing.prolongationOptions.prolongationTimeSec',
+					],
+				},
+			}
+		: {}),
 	[QueueType.INBOUND_JOB_QUEUE]: {
 		locale: baseLocale.concat('.inboundJobQueue'),
 		subpath: 'inbound-job-queue',

--- a/src/modules/contact-center/modules/queues/modules/filters/store/QueueTypeOptions.js
+++ b/src/modules/contact-center/modules/queues/modules/filters/store/QueueTypeOptions.js
@@ -1,10 +1,12 @@
 import { QueueType } from '@webitel/ui-sdk/enums';
 
 export default Object.keys(QueueType)
-
 	.filter(
 		(key) =>
-			Number.isNaN(+key) /* && QueueType[key] !== QueueType.IM_CHAT_QUEUE */, // hide me https://webitel.atlassian.net/browse/WS-2
+			Number.isNaN(+key) &&
+			// staging only https://webitel.atlassian.net/browse/WS-2
+			(import.meta.env.VITE_STAGING_ENV ||
+				QueueType[key] !== QueueType.IM_CHAT_QUEUE),
 	)
 	.map((key) => ({
 		name: key,


### PR DESCRIPTION
## Summary
- Show IM chat queue type only when `VITE_STAGING_ENV` is set
- Gate create-queue options and queue-type filter options the same way

## Test plan
- [ ] Without `VITE_STAGING_ENV`: IM chat queue absent from create-queue popup and type filters
- [ ] With `VITE_STAGING_ENV=true`: IM chat queue available in create and filters
- [ ] Other queue types unchanged


Made with [Cursor](https://cursor.com)