### PR TITLE
feat(agents): treat empty extra chat count as 0 (WTEL-10037)

### DIFF
--- a/src/modules/contact-center/modules/agents/api/agents.js
+++ b/src/modules/contact-center/modules/agents/api/agents.js
@@ -98,6 +98,7 @@ const getAgent = async ({ itemId: id }) => {
 		progressiveCount: null,
 		chatCount: 0,
 		taskCount: 0,
+		extraChatCount: 0,
 		isSupervisor: false,
 		description: '',
 		greetingMedia: {},

--- a/src/modules/contact-center/modules/agents/components/opened-agent.vue
+++ b/src/modules/contact-center/modules/agents/components/opened-agent.vue
@@ -92,6 +92,9 @@ export default {
 				required,
 				minValue: minValue(1),
 			},
+			extraChatCount: {
+				minValue: minValue(0),
+			},
 		},
 	},
 

--- a/src/modules/contact-center/modules/agents/store/agents.js
+++ b/src/modules/contact-center/modules/agents/store/agents.js
@@ -17,6 +17,7 @@ const resettableState = {
 		progressiveCount: null,
 		chatCount: 1,
 		taskCount: 1,
+		extraChatCount: 0,
 		isSupervisor: false,
 		screenControl: false,
 		greetingMedia: {},


### PR DESCRIPTION
Backend doesn't persist primitive fields equal to 0 as an optimization, so extraChatCount is defaulted to 0 on read/new-item state and negative values are now rejected by validation, mirroring how Storage Policy handles the same backend behavior.