### PR TITLE
fix(locale): remove unused minValue/maxValue validation messages (WTE…

### DIFF
--- a/src/app/locale/en/en.js
+++ b/src/app/locale/en/en.js
@@ -105,8 +105,6 @@ export default {
 		gatewayHostValidator: 'Should look like IPv4 or FQDN',
 		ipValidator: 'Should look like IPv4',
 		macValidator: 'Should look like MAC',
-		minValue: 'Value should be at least',
-		maxValue: 'Value should be not much',
 		numeric: 'Should be numeric',
 		requiredArrayValue: 'Array should not be empty',
 		isPositiveValue: 'Value should be positive number',

--- a/src/app/locale/es/es.js
+++ b/src/app/locale/es/es.js
@@ -105,8 +105,6 @@ export default {
 		gatewayHostValidator: 'Debe parecer una dirección IPv4 o FQDN',
 		ipValidator: 'Debe parecer una dirección IPv4',
 		macValidator: 'Debe parecer una dirección MAC',
-		minValue: 'El valor debe ser al menos',
-		maxValue: 'El valor no debe ser demasiado',
 		numeric: 'Debe ser numérico',
 		requiredArrayValue: 'El array no debe estar vacío',
 		isPositiveValue: 'El valor debe ser un número positivo',

--- a/src/app/locale/kz/kz.js
+++ b/src/app/locale/kz/kz.js
@@ -105,8 +105,6 @@ export default {
 		gatewayHostValidator: 'IPv4 немесе FQDN тәрізді болуы керек',
 		ipValidator: 'IPv4 тәрізді болуы керек',
 		macValidator: 'MAC тәрізді болуы керек',
-		minValue: 'Мән ең кем дегенде болуы керек',
-		maxValue: 'Мән ең көп емес болуы керек',
 		numeric: 'Сан болуы керек',
 		requiredArrayValue: 'Массив бос болмауы керек',
 		isPositiveValue: 'Мән оң сан болуы керек',

--- a/src/app/locale/pl/pl.js
+++ b/src/app/locale/pl/pl.js
@@ -107,8 +107,6 @@ export default {
 		gatewayHostValidator: 'Powinien wyglądać jak IPv4 lub FQDN',
 		ipValidator: 'Powinien wyglądać jak IPv4',
 		macValidator: 'Powinien wyglądać jak MAC',
-		minValue: 'Wartość powinna być co najmniej',
-		maxValue: 'Wartość powinna być nieco mniejsza',
 		numeric: 'Powinna być liczba',
 		requiredArrayValue: 'Tablica nie może być pusta',
 		isPositiveValue: 'Wartość powinna być liczbą dodatnią',

--- a/src/app/locale/ro/ro.js
+++ b/src/app/locale/ro/ro.js
@@ -105,8 +105,6 @@ export default {
 		gatewayHostValidator: 'Ar trebui să arate ca un IPv4 sau FQDN',
 		ipValidator: 'Ar trebui să arate ca un IPv4',
 		macValidator: 'Ar trebui să arate ca un MAC',
-		minValue: 'Valoarea ar trebui să fie cel puțin',
-		maxValue: 'Valoarea ar trebui să nu fie prea mare',
 		numeric: 'Ar trebui să fie numeric',
 		requiredArrayValue: 'Matricea nu ar trebui să fie goală',
 		isPositiveValue: 'Valoarea ar trebui să fie un număr pozitiv',

--- a/src/app/locale/ru/ru.js
+++ b/src/app/locale/ru/ru.js
@@ -109,8 +109,6 @@ export default {
 		gatewayHostValidator: 'Should look like IPv4 or FQDN',
 		ipValidator: 'Should look like IPv4',
 		macValidator: 'Should look like MAC',
-		minValue: 'Значение должно быть не менее',
-		maxValue: 'Значение должно быть не слишком большим',
 		numeric: 'Должны быть цифры',
 		requiredArrayValue: 'Поле не должно быть пустым',
 		isPositiveValue: 'Значение должно быть больше нуля',

--- a/src/app/locale/uk/uk.js
+++ b/src/app/locale/uk/uk.js
@@ -109,8 +109,6 @@ export default {
 		gatewayHostValidator: 'Має виглядати як IPv4 або FQDN',
 		ipValidator: 'Має виглядати як IPv4',
 		macValidator: 'Має виглядати як MAC',
-		minValue: 'Значення має бути не менше',
-		maxValue: 'Значення має бути не надто великим',
 		numeric: 'Мають бути цифри',
 		requiredArrayValue: 'Поле не може бути пустим',
 		isPositiveValue: 'Значення має бути додатнім числом',

--- a/src/app/locale/uz/uz.js
+++ b/src/app/locale/uz/uz.js
@@ -105,8 +105,6 @@ export default {
 		gatewayHostValidator: "IPv4 yoki FQDN shaklida bo'lishi kerak",
 		ipValidator: "IPv4 shaklida bo'lishi kerak",
 		macValidator: "MAC shaklida bo'lishi kerak",
-		minValue: 'Qiymat kamida',
-		maxValue: 'Qiymat kamida emas',
 		numeric: "Raqam bo'lishi kerak",
 		requiredArrayValue: "Massiv bo'sh bo'lmasligi kerak",
 		isPositiveValue: "Qiymat musbat son bo'lishi kerak",

--- a/src/app/locale/vi/vi.js
+++ b/src/app/locale/vi/vi.js
@@ -105,8 +105,6 @@ export default {
 		gatewayHostValidator: 'Phải giống IPv4 hoặc FQDN',
 		ipValidator: 'Phải giống IPv4',
 		macValidator: 'Phải giống MAC',
-		minValue: 'Giá trị phải ít nhất là',
-		maxValue: 'Giá trị không được lớn hơn',
 		numeric: 'Phải là số',
 		requiredArrayValue: 'Mảng không được rỗng',
 		isPositiveValue: 'Giá trị phải là số dương',


### PR DESCRIPTION
…L-10037)

These generic messages are no longer referenced now that extra chat count validation uses a dedicated helper text instead.